### PR TITLE
Fixed error in cmsmap installation and add nbtscan package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get install -y \
         hydra \
         ike-scan \
         metasploit-framework \
+        nbtscan \
         netcat \
         nfs-common \
         nikto \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get install -y \
         dnsrecon \
         dnsutils \
         enum4linux \
+        exploitdb \
         finger \
         git \
         hydra \

--- a/git/install.sh
+++ b/git/install.sh
@@ -68,5 +68,10 @@ echo ""
 write_main "Installing cmsmap"
 git clone https://github.com/Dionach/CMSmap.git
 cd CMSmap/
+cat << EOF > cmsmap.conf
+[exploitdb]
+edbtype = APT
+edbpath = /usr/share/exploitdb/
+EOF
 pip3 install .
 echo ""


### PR DESCRIPTION
Hi @carlospolop, earlier I forgot to add the `cmsmap.conf` file during installation.
Adding this, `cmsmap` is able to use the `exploitdb` package to check its results.
Moreover, during some tests, I noticed about the lack of `nbtscan` package.
Sorry for my oversight.